### PR TITLE
refactor(helm): Medcat-service-helm  downloader should its own image

### DIFF
--- a/helm-charts/local_dev_startup.sh
+++ b/helm-charts/local_dev_startup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-minikube start --cni=calico --cpus=no-limit --memory=no-limit
+export MINIKUBE_HOME="$HOME/.minikube-${HOSTNAME}"
+export KUBECONFIG="$HOME/.kube/config-${HOSTNAME}"
+minikube start -p cogstack-platform --cni=calico --cpus=no-limit --memory=no-limit
 minikube addons enable metrics-server
 
 minikube dashboard --url=true &

--- a/helm-charts/medcat-service-helm/README.md
+++ b/helm-charts/medcat-service-helm/README.md
@@ -39,7 +39,6 @@ Create a values file like `values-model-download.yaml` and set these values:
 ```yaml
 model:
   downloadUrl: "http://localhost:9000/models/my-model.zip"
-  name: my-model.zip
 ```
 
 Use this if you prefer dynamic loading of models at runtime.

--- a/helm-charts/medcat-service-helm/README.md.gotmpl
+++ b/helm-charts/medcat-service-helm/README.md.gotmpl
@@ -42,7 +42,6 @@ Create a values file like `values-model-download.yaml` and set these values:
 ```yaml
 model:
   downloadUrl: "http://localhost:9000/models/my-model.zip"
-  name: my-model.zip
 ```
 
 Use this if you prefer dynamic loading of models at runtime.

--- a/helm-charts/medcat-service-helm/templates/_helpers.tpl
+++ b/helm-charts/medcat-service-helm/templates/_helpers.tpl
@@ -15,7 +15,8 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
+{{- $basename := $name | trimSuffix "-helm" }}
+{{- if or (contains $name .Release.Name) (eq .Release.Name $basename) }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}

--- a/helm-charts/medcat-service-helm/templates/deployment.yaml
+++ b/helm-charts/medcat-service-helm/templates/deployment.yaml
@@ -56,13 +56,17 @@ spec:
               {{- tpl (toYaml $value) $ | nindent 14 }}
           {{- end }}
           {{- range $key, $value := .Values.env }}
+          {{- if ne $key "APP_MEDCAT_MODEL_PACK" }}
           - name: "{{ tpl $key $ }}"
             value: "{{ tpl (print $value) $ }}"
           {{- end }}
+          {{- end }}
           {{- if .Values.model.downloadUrl }}
-          # Note this overrides any previous env setting if downloading is enabled
           - name: "APP_MEDCAT_MODEL_PACK"
-            value: "/models/{{ .Values.model.name}}"
+            value: '/models/{{ default "medcat-model.zip" .Values.model.name }}'
+          {{ else }}
+          - name: "APP_MEDCAT_MODEL_PACK"
+            value: {{ .Values.env.APP_MEDCAT_MODEL_PACK | quote }}
           {{- end}}
           {{- with .Values.livenessProbe }}
           livenessProbe:
@@ -95,24 +99,32 @@ spec:
       {{- end }}
       {{- if .Values.model.downloadUrl }}
         - name: model-downloader
-          image: busybox:1.28
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command: 
             - sh
             - -c
             - |
-              echo "Downloading model $MODEL_NAME from $MODEL_PACK_URL"
+              set -e
+              echo "Downloading model to $APP_MEDCAT_MODEL_PACK from $MODEL_PACK_URL"
               mkdir -p /models
-              wget -O "/models/$MODEL_NAME" "$MODEL_PACK_URL"
-              if [ $? -ne 0 ]; then
-                echo "Failed to download model from $MODEL_PACK_URL" >&2
-                exit 1
-              fi
+              python - <<'PY'
+              import os
+              import requests
+
+              url = os.environ["MODEL_PACK_URL"]
+              path = os.environ.get("APP_MEDCAT_MODEL_PACK")
+
+              r = requests.get(url, allow_redirects=True)
+              r.raise_for_status()
+              with open(path, "wb") as f:
+                  f.write(r.content)
+              PY
               echo "Download finished successfully"
           env:
           - name: MODEL_PACK_URL
             value: {{ .Values.model.downloadUrl}}
-          - name: MODEL_NAME
-            value: {{ .Values.model.name}}
+          - name: APP_MEDCAT_MODEL_PACK
+            value: '/models/{{ default "medcat-model.zip" .Values.model.name }}'
           volumeMounts:
             - name: models
               mountPath: /models


### PR DESCRIPTION
- Use the medcat-service image for model downloading. Rewrite in python as curl/wget not available
- Make MODEL_NAME an optional value
- Improve the name parsing, if you use the release name "medcat-service" it will now use pod name "medcat-service" instead of "medcat-service-medcat-service-helm"