### PR TITLE
ci: Lint PR titles against Conventional Commits standard

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,19 @@
+name: PR - Lint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint-pr-title:
+    name: Validate PR title (Conventional Commits)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Summary

This pull request runs a GHA (https://github.com/amannn/action-semantic-pull-request) to enforce that PR titles adhere to the Conventional Commits standard.
